### PR TITLE
#16 - fix incorrect index check on volume build

### DIFF
--- a/src/services/buildWorkoutVolumeByWeek.js
+++ b/src/services/buildWorkoutVolumeByWeek.js
@@ -23,7 +23,7 @@ export function buildWorkoutVolumeByWeek(instance) {
     const weekNumber = getWeek(workoutDate, getWeekOptions);
     const year = getYear(workoutDate);
     const weekYear = weekNumber + '-' + year;
-    if (idx > 1) {
+    if (idx >= 1) {
       const lastWorkoutDate = new Date(workouts[idx - 1].WorkoutDate);
       const lastYear = getYear(lastWorkoutDate);
       const lastWeek = getWeek(lastWorkoutDate, getWeekOptions);


### PR DESCRIPTION
Check for index >= 1 when comparing rows rather than index > 1